### PR TITLE
Bug fix "floatrow ! No room for a new \dimen"

### DIFF
--- a/epsrc.tex
+++ b/epsrc.tex
@@ -1,5 +1,6 @@
 \documentclass{epsrc}
 
+
 %----These packages are only needed for drafts-----%
 \usepackage{lipsum} % used for dummy text
 \usepackage[colorinlistoftodos,prependcaption,textsize=tiny]{todonotes}%to do list and comments
@@ -8,8 +9,8 @@
 
 
 %I use these routinely but may not be needed
-\usepackage[version=3]{mhchem}
 \usepackage{chemstyle}
+\usepackage[version=3]{mhchem}
 \usepackage{graphicx}
 \usepackage{amsmath}
 \usepackage{amsfonts}


### PR DESCRIPTION
Hi

I see a "floatrow ! No room for a new \dimen" error when I compile the source on my mac with MacTeX-2015. This is due to that texlive2015 no longer loads etex.sty (https://www.tug.org/pipermail/tex-live/2015-June/037043.html)

The problem can be fixed by simply reorder the chemstyle package.

Best, 

Yue
